### PR TITLE
Direct Requests to Admin for Employees Without Managers

### DIFF
--- a/src/app/api/admin/requests/route.ts
+++ b/src/app/api/admin/requests/route.ts
@@ -12,29 +12,30 @@ export async function GET(req: Request) {
 
   try {
     const requests = await db.leaveRequest.findMany({
-        where: {
-            status: 'APPROVED_BY_MANAGER'
+      where: {
+        status: {
+          in: ['APPROVED_BY_MANAGER', 'PENDING_ADMIN'],
         },
-        include: {
-            employee: {
-                select: {
-                    firstName: true,
-                    lastName: true,
-                }
-            },
-            leaveType: {
-                select: {
-                    name: true,
-                }
-            }
+      },
+      include: {
+        employee: {
+          select: {
+            firstName: true,
+            lastName: true,
+          },
         },
-        orderBy: {
-            createdAt: 'asc'
-        }
+        leaveType: {
+          select: {
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
     });
 
     return NextResponse.json(requests);
-
   } catch (error) {
     console.error("[ADMIN_REQUESTS_GET_ERROR]", error);
     return new NextResponse("Internal Server Error", { status: 500 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,6 +44,7 @@ type Request = {
       changedBy: { email: string };
   }[];
   hasOverlap?: boolean;
+  skipReason?: string | null;
 }
 type Balance = {
   id: string;
@@ -186,7 +187,7 @@ export default function DashboardPage() {
     }
     setIsDenyDialogOpen(false);
     setDenialReason('');
-    setOtherReason('');
+       setOtherReason('');
     setIsCancellationRejection(false);
   };
   
@@ -263,8 +264,20 @@ export default function DashboardPage() {
 
   const hrPendingContent = pendingHrRequests.concat(pendingHrCancellations).map(req => {
       const isCancellation = req.status === 'CANCELLATION_PENDING_ADMIN';
+      const showSkip = req.status === 'PENDING_ADMIN' && req.skipReason;
       return (
-        <TableRow key={req.id} className={isCancellation ? "bg-yellow-100" : ""}><TableCell>{req.employee.firstName} {req.employee.lastName}</TableCell><TableCell>{req.leaveType.name} {isCancellation && '(Cancellation)'}</TableCell><TableCell>{format(new Date(req.startDate), 'PPP')} - {format(new Date(req.endDate), 'PPP')}</TableCell><TableCell className="text-right space-x-2"><Button size="sm" variant="outline" onClick={() => { setCurrentRequestToAction(req); setIsDenyDialogOpen(true); setIsCancellationRejection(isCancellation); }}>Deny</Button><Button size="sm" onClick={() => isCancellation ? handleCancellationApproval(req.id, 'APPROVE') : handleRequestAction(req.id, 'APPROVED_BY_ADMIN')}>Final Approve</Button></TableCell></TableRow>
+        <TableRow key={req.id} className={isCancellation ? "bg-yellow-100" : ""}>
+          <TableCell>
+            {req.employee.firstName} {req.employee.lastName}
+            {showSkip && (<div className="text-xs text-muted-foreground mt-1">Override: {req.skipReason}</div>)}
+          </TableCell>
+          <TableCell>{req.leaveType.name} {isCancellation && '(Cancellation)'}</TableCell>
+          <TableCell>{format(new Date(req.startDate), 'PPP')} - {format(new Date(req.endDate), 'PPP')}</TableCell>
+          <TableCell className="text-right space-x-2">
+            <Button size="sm" variant="outline" onClick={() => { setCurrentRequestToAction(req); setIsDenyDialogOpen(true); setIsCancellationRejection(isCancellation); }}>Deny</Button>
+            <Button size="sm" onClick={() => isCancellation ? handleCancellationApproval(req.id, 'APPROVE') : handleRequestAction(req.id, 'APPROVED_BY_ADMIN')}>Final Approve</Button>
+          </TableCell>
+        </TableRow>
       );
   });
   


### PR DESCRIPTION
This PR modifies the leave request handling so that if an employee has no manager or their manager is on leave, the request will be directed to the admin or superadmin. Changes include updates to the database queries to include requests with either 'APPROVED_BY_MANAGER' or 'PENDING_ADMIN' status. Additionally, a new property 'skipReason' is introduced to the DashboardPage component to display the reason for the request bypassing the manager. Overall, these updates ensure that leave requests are properly handled without unnecessary delays.

---

> This pull request was co-created with Cosine Genie

Original Task: [uptown6octoberhr/r2jjyxhf7qut](https://cosine.sh/epj61kf07sll/uptown6octoberhr/task/r2jjyxhf7qut)
Author: ramynoureldien
