### PR TITLE
Make Admin Header Sticky Across All Admin Pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
+import { DashboardHeader } from "@/components/DashboardHeader";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,7 +19,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <DashboardHeader />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/headers/AdminHeader.tsx
+++ b/src/components/headers/AdminHeader.tsx
@@ -1,12 +1,21 @@
 // File: src/components/headers/AdminHeader.tsx
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function AdminHeader() {
   const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const nav = [
+    { href: '/admin/employees', label: 'Employees' },
+    { href: '/admin/holidays', label: 'Holidays' },
+    { href: '/admin/work-schedules', label: 'Schedules' },
+  ];
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b">
@@ -19,18 +28,23 @@ export function AdminHeader() {
         </p>
       </div>
       <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
-        <Button asChild variant="ghost" size="sm">
-          <Link href="/admin/employees">Employees</Link>
-        </Button>
-        <Button asChild variant="ghost" size="sm">
-          <Link href="/admin/holidays">Holidays</Link>
-        </Button>
-        <Button asChild variant="ghost" size="sm">
-          <Link href="/admin/work-schedules">Schedules</Link>
-        </Button>
-        <Button 
-          onClick={() => signOut({ callbackUrl: '/login' })} 
-          variant="destructive" 
+        {nav.map((item) => {
+          const active = pathname?.startsWith(item.href);
+          return (
+            <Button
+              key={item.href}
+              asChild
+              size="sm"
+              variant={active ? 'secondary' : 'ghost'}
+              className={cn(active && 'ring-1 ring-ring')}
+            >
+              <Link href={item.href}>{item.label}</Link>
+            </Button>
+          );
+        })}
+        <Button
+          onClick={() => signOut({ callbackUrl: '/login' })}
+          variant="destructive"
           size="sm"
         >
           Log Out

--- a/src/components/headers/EmployeeHeader.tsx
+++ b/src/components/headers/EmployeeHeader.tsx
@@ -1,12 +1,12 @@
 // File: src/components/headers/EmployeeHeader.tsx
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
 export function EmployeeHeader() {
-  const {  session } = useSession();
+  const { data: session } = useSession();
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b">

--- a/src/components/headers/EmployeeHeader.tsx
+++ b/src/components/headers/EmployeeHeader.tsx
@@ -3,10 +3,19 @@
 
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function EmployeeHeader() {
   const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const nav = [
+    { href: '/dashboard', label: 'My Dashboard' },
+    { href: '/dashboard/leave/request', label: 'Request Leave' },
+    { href: '/dashboard/settings', label: 'Settings' },
+  ];
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b">
@@ -18,7 +27,21 @@ export function EmployeeHeader() {
           Welcome, {session?.user?.email}
         </p>
       </div>
-      <div className="w-full sm:w-auto">
+      <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
+        {nav.map((item) => {
+          const active = pathname === item.href || pathname?.startsWith(item.href);
+          return (
+            <Button
+              key={item.href}
+              asChild
+              size="sm"
+              variant={active ? 'secondary' : 'ghost'}
+              className={cn(active && 'ring-1 ring-yellow-500')}
+            >
+              <Link href={item.href}>{item.label}</Link>
+            </Button>
+          );
+        })}
         <Button 
           onClick={() => signOut({ callbackUrl: '/login' })} 
           variant="destructive" 

--- a/src/components/headers/ManagerHeader.tsx
+++ b/src/components/headers/ManagerHeader.tsx
@@ -3,10 +3,19 @@
 
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function ManagerHeader() {
   const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const nav = [
+    { href: '/dashboard/manager', label: 'Manager Dashboard' },
+    { href: '/dashboard/reports', label: 'Reports' },
+    { href: '/dashboard/settings', label: 'Settings' },
+  ];
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b shadow-sm">
@@ -21,7 +30,21 @@ export function ManagerHeader() {
           Manager Mode
         </p>
       </div>
-      <div className="w-full sm:w-auto">
+      <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
+        {nav.map((item) => {
+          const active = pathname?.startsWith(item.href);
+          return (
+            <Button
+              key={item.href}
+              asChild
+              size="sm"
+              variant={active ? 'secondary' : 'ghost'}
+              className={cn(active && 'ring-1 ring-yellow-500')}
+            >
+              <Link href={item.href}>{item.label}</Link>
+            </Button>
+          );
+        })}
         <Button 
           onClick={() => signOut({ callbackUrl: '/login' })} 
           variant="destructive" 

--- a/src/components/headers/ManagerHeader.tsx
+++ b/src/components/headers/ManagerHeader.tsx
@@ -1,12 +1,12 @@
 // File: src/components/headers/ManagerHeader.tsx
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
 export function ManagerHeader() {
-  const {  session } = useSession();
+  const { data: session } = useSession();
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b shadow-sm">

--- a/src/components/headers/SuperAdminHeader.tsx
+++ b/src/components/headers/SuperAdminHeader.tsx
@@ -1,12 +1,22 @@
 // File: src/components/headers/SuperAdminHeader.tsx
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function SuperAdminHeader() {
-  const {  session } = useSession();
+  const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const nav = [
+    { href: '/admin/employees', label: 'Employees' },
+    { href: '/admin/holidays', label: 'Holidays' },
+    { href: '/admin/work-schedules', label: 'Schedules' },
+    { href: '/admin/manage-admins', label: 'Manage Admins', highlight: true },
+  ];
 
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-gradient-to-r from-red-600 to-pink-700 text-white shadow-lg rounded-b-lg">
@@ -23,21 +33,27 @@ export function SuperAdminHeader() {
       </div>
       <div className="w-full sm:w-auto">
         <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2 flex-wrap justify-end gap-2">
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/admin/employees">Employees</Link>
-          </Button>
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/admin/holidays">Holidays</Link>
-          </Button>
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/admin/work-schedules">Schedules</Link>
-          </Button>
-          <Button asChild variant="outline" size="sm" className="bg-white text-red-700 hover:bg-gray-100">
-            <Link href="/admin/manage-admins">Manage Admins</Link>
-          </Button>
-          <Button 
-            onClick={() => signOut({ callbackUrl: '/login' })} 
-            variant="ghost" 
+          {nav.map((item) => {
+            const active = pathname?.startsWith(item.href);
+            const variant = active ? 'outline' : item.highlight ? 'outline' : 'secondary';
+            const baseClasses = item.highlight
+              ? 'bg-white text-red-700 hover:bg-gray-100'
+              : '';
+            return (
+              <Button
+                key={item.href}
+                asChild
+                size="sm"
+                variant={variant as any}
+                className={cn(baseClasses, active && 'ring-1 ring-white/70')}
+              >
+                <Link href={item.href}>{item.label}</Link>
+              </Button>
+            );
+          })}
+          <Button
+            onClick={() => signOut({ callbackUrl: '/login' })}
+            variant="ghost"
             size="sm"
             className="bg-white text-red-700 hover:bg-gray-100 font-medium w-full sm:w-auto"
           >


### PR DESCRIPTION
This pull request ensures that the Admin Header, containing the admin's email and shortcut links, remains visible as the admin navigates through different pages, including the Super Admin and Manager pages. 

Changes include:
- Introduced the `DashboardHeader` component in `layout.tsx` to persist the header across page navigations.
- Updated `AdminHeader`, `EmployeeHeader`, `ManagerHeader`, and `SuperAdminHeader` to include dynamic navigation buttons that indicate the active page. 

This enhancement improves the user experience by providing quick navigation access regardless of the page the admin is on.

---

> This pull request was co-created with Cosine Genie

Original Task: [uptown6octoberhr/4j9rhysjomq8](https://cosine.sh/epj61kf07sll/uptown6octoberhr/task/4j9rhysjomq8)
Author: ramynoureldien
