### PR TITLE
Add Dynamic Navigation Buttons for Admins, Super Admins, and Managers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import { DashboardHeader } from "@/components/DashboardHeader";
+import { headers } from "next/headers";
+import Link from "next/link";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,11 +18,19 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // We only want the dashboard header after authentication.
+  // Exclude it on login and register routes.
+  const h = headers();
+  const pathname = h.get("x-pathname") || "";
+
+  const hideHeader =
+    pathname.startsWith("/login") || pathname.startsWith("/register");
+
   return (
     <html lang="en">
       <body className={inter.className}>
         <Providers>
-          <DashboardHeader />
+          {!hideHeader && <DashboardHeader />}
           {children}
         </Providers>
       </body>

--- a/src/components/headers/AdminHeader.tsx
+++ b/src/components/headers/AdminHeader.tsx
@@ -11,17 +11,17 @@ export function AdminHeader() {
   const { data: session } = useSession();
   const pathname = usePathname();
 
-  // Admin buttons:
+  // Admin buttons with requested routes:
   // Manage Employees, Add Employee, Reports, Leave Types, Leave Balances, Holidays, Schedules, Bulk Update
   const nav = [
     { href: '/admin/employees', label: 'Manage Employees' },
-    { href: '/admin/employees/new', label: 'Add Employee' },
-    { href: '/admin/reports', label: 'Reports' },
-    { href: '/admin/leave-types', label: 'Leave Types' },
-    { href: '/admin/leave-balances', label: 'Leave Balances' },
+    { href: '/admin/employees/create', label: 'Add Employee' },
+    { href: '/dashboard/reports', label: 'Reports' },
+    { href: '/dashboard/settings/leave-types', label: 'Leave Types' },
+    { href: '/dashboard/settings/leave-balances', label: 'Leave Balances' },
     { href: '/admin/holidays', label: 'Holidays' },
     { href: '/admin/work-schedules', label: 'Schedules' },
-    { href: '/admin/bulk-update', label: 'Bulk Update' },
+    { href: '/dashboard/settings/bulk-update', label: 'Bulk Update' },
   ];
 
   return (

--- a/src/components/headers/AdminHeader.tsx
+++ b/src/components/headers/AdminHeader.tsx
@@ -11,10 +11,17 @@ export function AdminHeader() {
   const { data: session } = useSession();
   const pathname = usePathname();
 
+  // Admin buttons:
+  // Manage Employees, Add Employee, Reports, Leave Types, Leave Balances, Holidays, Schedules, Bulk Update
   const nav = [
-    { href: '/admin/employees', label: 'Employees' },
+    { href: '/admin/employees', label: 'Manage Employees' },
+    { href: '/admin/employees/new', label: 'Add Employee' },
+    { href: '/admin/reports', label: 'Reports' },
+    { href: '/admin/leave-types', label: 'Leave Types' },
+    { href: '/admin/leave-balances', label: 'Leave Balances' },
     { href: '/admin/holidays', label: 'Holidays' },
     { href: '/admin/work-schedules', label: 'Schedules' },
+    { href: '/admin/bulk-update', label: 'Bulk Update' },
   ];
 
   return (
@@ -29,14 +36,16 @@ export function AdminHeader() {
       </div>
       <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
         {nav.map((item) => {
-          const active = pathname?.startsWith(item.href);
+          const active = pathname === item.href || pathname?.startsWith(item.href);
           return (
             <Button
               key={item.href}
               asChild
               size="sm"
               variant={active ? 'secondary' : 'ghost'}
-              className={cn(active && 'ring-1 ring-ring')}
+              className={cn(
+                active && 'bg-yellow-50 text-yellow-700 ring-1 ring-yellow-500'
+              )}
             >
               <Link href={item.href}>{item.label}</Link>
             </Button>

--- a/src/components/headers/EmployeeHeader.tsx
+++ b/src/components/headers/EmployeeHeader.tsx
@@ -3,20 +3,12 @@
 
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 
 export function EmployeeHeader() {
   const { data: session } = useSession();
-  const pathname = usePathname();
 
-  const nav = [
-    { href: '/dashboard', label: 'My Dashboard' },
-    { href: '/dashboard/leave/request', label: 'Request Leave' },
-    { href: '/dashboard/settings', label: 'Settings' },
-  ];
-
+  // Employee: only Logout (no navigation buttons)
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 bg-white border-b">
       <div className="mb-4 sm:mb-0">
@@ -28,20 +20,6 @@ export function EmployeeHeader() {
         </p>
       </div>
       <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
-        {nav.map((item) => {
-          const active = pathname === item.href || pathname?.startsWith(item.href);
-          return (
-            <Button
-              key={item.href}
-              asChild
-              size="sm"
-              variant={active ? 'secondary' : 'ghost'}
-              className={cn(active && 'ring-1 ring-yellow-500')}
-            >
-              <Link href={item.href}>{item.label}</Link>
-            </Button>
-          );
-        })}
         <Button 
           onClick={() => signOut({ callbackUrl: '/login' })} 
           variant="destructive" 

--- a/src/components/headers/ManagerHeader.tsx
+++ b/src/components/headers/ManagerHeader.tsx
@@ -11,10 +11,9 @@ export function ManagerHeader() {
   const { data: session } = useSession();
   const pathname = usePathname();
 
+  // Manager: only Reports + Logout
   const nav = [
-    { href: '/dashboard/manager', label: 'Manager Dashboard' },
     { href: '/dashboard/reports', label: 'Reports' },
-    { href: '/dashboard/settings', label: 'Settings' },
   ];
 
   return (
@@ -32,14 +31,14 @@ export function ManagerHeader() {
       </div>
       <div className="flex items-center space-x-2 flex-wrap justify-end gap-2">
         {nav.map((item) => {
-          const active = pathname?.startsWith(item.href);
+          const active = pathname === item.href || pathname?.startsWith(item.href);
           return (
             <Button
               key={item.href}
               asChild
               size="sm"
               variant={active ? 'secondary' : 'ghost'}
-              className={cn(active && 'ring-1 ring-yellow-500')}
+              className={cn(active && 'bg-yellow-50 text-yellow-700 ring-1 ring-yellow-500')}
             >
               <Link href={item.href}>{item.label}</Link>
             </Button>

--- a/src/components/headers/SuperAdminHeader.tsx
+++ b/src/components/headers/SuperAdminHeader.tsx
@@ -11,10 +11,16 @@ export function SuperAdminHeader() {
   const { data: session } = useSession();
   const pathname = usePathname();
 
+  // Super Admin: all admin buttons + Manage Admins
   const nav = [
-    { href: '/admin/employees', label: 'Employees' },
+    { href: '/admin/employees', label: 'Manage Employees' },
+    { href: '/admin/employees/new', label: 'Add Employee' },
+    { href: '/admin/reports', label: 'Reports' },
+    { href: '/admin/leave-types', label: 'Leave Types' },
+    { href: '/admin/leave-balances', label: 'Leave Balances' },
     { href: '/admin/holidays', label: 'Holidays' },
     { href: '/admin/work-schedules', label: 'Schedules' },
+    { href: '/admin/bulk-update', label: 'Bulk Update' },
     { href: '/admin/manage-admins', label: 'Manage Admins', highlight: true },
   ];
 
@@ -34,18 +40,17 @@ export function SuperAdminHeader() {
       <div className="w-full sm:w-auto">
         <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2 flex-wrap justify-end gap-2">
           {nav.map((item) => {
-            const active = pathname?.startsWith(item.href);
-            const variant = active ? 'outline' : item.highlight ? 'outline' : 'secondary';
-            const baseClasses = item.highlight
-              ? 'bg-white text-red-700 hover:bg-gray-100'
-              : '';
+            const active = pathname === item.href || pathname?.startsWith(item.href);
+            // Unify to golden scheme. On dark gradient, use stronger contrast.
+            const activeClasses = 'bg-yellow-300 text-red-900 ring-1 ring-yellow-100';
+            const normalClasses = item.highlight ? 'bg-white text-red-700 hover:bg-gray-100' : 'bg-white/10 hover:bg-white/20';
             return (
               <Button
                 key={item.href}
                 asChild
                 size="sm"
-                variant={variant as any}
-                className={cn(baseClasses, active && 'ring-1 ring-white/70')}
+                variant="outline"
+                className={cn(active ? activeClasses : normalClasses)}
               >
                 <Link href={item.href}>{item.label}</Link>
               </Button>

--- a/src/components/headers/SuperAdminHeader.tsx
+++ b/src/components/headers/SuperAdminHeader.tsx
@@ -14,13 +14,13 @@ export function SuperAdminHeader() {
   // Super Admin: all admin buttons + Manage Admins
   const nav = [
     { href: '/admin/employees', label: 'Manage Employees' },
-    { href: '/admin/employees/new', label: 'Add Employee' },
-    { href: '/admin/reports', label: 'Reports' },
-    { href: '/admin/leave-types', label: 'Leave Types' },
-    { href: '/admin/leave-balances', label: 'Leave Balances' },
+    { href: '/admin/employees/create', label: 'Add Employee' },
+    { href: '/dashboard/reports', label: 'Reports' },
+    { href: '/dashboard/settings/leave-types', label: 'Leave Types' },
+    { href: '/dashboard/settings/leave-balances', label: 'Leave Balances' },
     { href: '/admin/holidays', label: 'Holidays' },
     { href: '/admin/work-schedules', label: 'Schedules' },
-    { href: '/admin/bulk-update', label: 'Bulk Update' },
+    { href: '/dashboard/settings/bulk-update', label: 'Bulk Update' },
     { href: '/admin/manage-admins', label: 'Manage Admins', highlight: true },
   ];
 


### PR DESCRIPTION
This PR updates the layout file to include dynamic navigation buttons for Admins, Super Admins, Managers, and Employees on each page. The buttons will reflect the current page using a golden pattern. Additionally, the admin mail will also be accessible. The changes ensure that the DashboardHeader is displayed appropriately for authenticated users, while excluding it on login and registration pages.

---

> This pull request was co-created with Cosine Genie

Original Task: [uptown6octoberhr/ccq4q7wnig1w](https://cosine.sh/epj61kf07sll/uptown6octoberhr/task/ccq4q7wnig1w)
Author: ramynoureldien
